### PR TITLE
fix: adjust theme after reload

### DIFF
--- a/src/shared/components/Header/index.jsx
+++ b/src/shared/components/Header/index.jsx
@@ -6,53 +6,52 @@ import styles from './styles';
 import { useAppThemeContext } from '../../contexts';
 import { useNavigate } from 'react-router-dom';
 
-
 export function Header({isLoggedIn}) {
-
   const { themeName, toggleTheme } = useAppThemeContext();
   const navigate = useNavigate();
+
+  const logoPucpr = themeName === 'light'  ? LogoLight : LogoDark;
 
   const handleNavigation = (hash) => {
     navigate(`/about${hash}`, { replace: true });
   };
-
-  const logoPucpr = themeName === 'light' ? LogoLight : LogoDark;
   
   return (
-  <>
-    { isLoggedIn ? (
-      
-      <Box sx={styles.headerContainer}>
-        <Box sx={styles.imageContainer} onClick={() => navigate('/home')}>
-          <img src={logoPucpr} alt="Logo da PUCPR" style={styles.logo} />
-        </Box>
-        <Box sx={styles.menuContainer}>
-          <Button color="secondary" onClick={() => handleNavigation('#about')} sx={styles.button}>Sobre</Button>
-          <Button color="secondary" onClick={() => handleNavigation('#guide')} sx={styles.button}>Manual</Button>
-          <Button color="secondary" sx={styles.button} onClick={toggleTheme}>Alto Contraste</Button>
-          <Button color="primary" variant='contained' onClick={() => navigate('/extract')} sx={styles.button}>Extrair</Button>
-        </Box>
-      </Box>
-    ) : (
-      <Box sx={styles.headerContainer}>
-      <Box sx={{
-          flexGrow: 1,
-          display: 'flex', 
-          alignItems: 'center'
-        }}>
-          <img src={logoPucpr} alt="Logo da PUCPR" style={styles.logo} />
-      </Box>
-      <Box sx={styles.menuContainer}>
-       <Button color="secondary" sx={{
-          borderRadius: '24px',
-          textTransform: 'none',
-          alignItems: 'right'
-        }} onClick={toggleTheme}>Alto Contraste</Button>
-      </Box>
+  <>      
+    <Box sx={styles.headerContainer}>
+
+      { isLoggedIn ? (
+        <>
+          <Box sx={styles.imageContainer} onClick={() => navigate('/home')}>
+            <img src={logoPucpr} alt="Logo da PUCPR" style={styles.logo} />
+          </Box>
+          <Box sx={styles.menuContainer}>
+            <Button color="secondary" onClick={() => handleNavigation('#about')} sx={styles.button}>Sobre</Button>
+            <Button color="secondary" onClick={() => handleNavigation('#guide')} sx={styles.button}>Manual</Button>
+            <Button color="secondary" sx={styles.button} onClick={toggleTheme}>Alto Contraste</Button>
+            <Button color="primary" variant='contained' onClick={() => navigate('/extract')} sx={styles.button}>Extrair</Button>
+          </Box>
+        </>
+      ) : (
+        <>
+          <Box sx={{
+            flexGrow: 1,
+            display: 'flex', 
+            alignItems: 'center'
+          }}>
+            <img src={logoPucpr} alt="Logo da PUCPR" style={styles.logo} />
+          </Box>
+          <Box sx={styles.menuContainer}>
+            <Button color="secondary" sx={{
+              borderRadius: '24px',
+              textTransform: 'none',
+              alignItems: 'right'
+            }} onClick={toggleTheme}>Alto Contraste</Button>
+          </Box>
+        </>
+      )}
+
     </Box>
-    )
-  }
   </>
   );
 }
-  

--- a/src/shared/contexts/ThemeContext.jsx
+++ b/src/shared/contexts/ThemeContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { ThemeProvider } from '@mui/material';
 import { Box } from '@mui/system';
 
@@ -12,11 +12,18 @@ export const useAppThemeContext = () => {
 }
 
 export const AppThemeProvider = ({ children }) => {
-  const [themeName, setThemeName] = useState('light');
+  const [themeName, setThemeName] = useState();
 
-  const toggleTheme = useCallback(() => {
-    setThemeName(oldThemeName => oldThemeName === 'light' ? 'dark' : 'light');
+  useEffect(() => {
+    const savedTheme = sessionStorage.getItem('theme') || 'light';
+    setThemeName(savedTheme);
   }, []);
+
+  const toggleTheme = () => {
+    const newTheme = themeName === 'light' ? 'dark' : 'light';
+    setThemeName(newTheme);
+    sessionStorage.setItem('theme', newTheme);
+  };
 
   const theme = useMemo(() => {
     if (themeName === 'light') return LightTheme;


### PR DESCRIPTION
After reloading the page, the theme (dark) was lost and returned to the light theme.
Adjusted in the theme context, using sessionStorage to save the user's last option.